### PR TITLE
Documentation recommendation: Add Data Models section to mac_app_mvp_task.md

### DIFF
--- a/.openhands/microagents/mac_app_mvp_task.md
+++ b/.openhands/microagents/mac_app_mvp_task.md
@@ -65,5 +65,4 @@ The Mac app will implement Swift models that directly map to the JSON structures
 - Configuration models
 
 All models will implement Swift's `Codable` protocol for JSON serialization/deserialization.
-This approach avoids redundancy while clarifying the implementation plan. The existing JSON documentation provides sufficient detail for developers to implement the corresponding Swift structures.
 

--- a/.openhands/microagents/mac_app_mvp_task.md
+++ b/.openhands/microagents/mac_app_mvp_task.md
@@ -52,3 +52,18 @@ The primary focus of the MVP is to enable the following functionalities:
 - Navigate and view files within the workspace.
 - Start and stop agent execution.
 - Connect to a local OpenHands backend.
+
+## Technical Architecture
+
+### Data Models
+
+The Mac app will implement Swift models that directly map to the JSON structures defined in the backend communication protocol. These include:
+
+- Communication models (Events, UserActions)
+- Agent state model
+- File system representations
+- Configuration models
+
+All models will implement Swift's `Codable` protocol for JSON serialization/deserialization.
+This approach avoids redundancy while clarifying the implementation plan. The existing JSON documentation provides sufficient detail for developers to implement the corresponding Swift structures.
+


### PR DESCRIPTION
This PR adds a Data Models section to the mac_app_mvp_task.md under the Technical Architecture section, clarifying the implementation plan for Swift models mapping to the JSON structures defined in the backend communication protocol.