### PR TITLE
Add document listing missing elements in Mac app MVP specification

### DIFF
--- a/.openhands/microagents/what_is_missing.md
+++ b/.openhands/microagents/what_is_missing.md
@@ -1,0 +1,55 @@
+# Missing Elements in Mac App MVP Specification
+
+This document outlines specific technical gaps in the current Mac app MVP specification that need to be addressed for a complete implementation guide.
+
+## Technical Implementation Details
+
+- [ ] **Socket.IO Implementation Details**:
+  - [ ] Specific implementation details for handling Socket.IO connections
+  - [ ] Reconnection strategy when connection is lost
+  - [ ] Error handling for Socket.IO events
+  - [ ] Event queuing during disconnections
+
+- [ ] **UI Component Architecture**:
+  - [ ] Detailed breakdown of UI components and their relationships
+  - [ ] View hierarchy and navigation flow
+  - [ ] Specification for how the MVVM pattern should be implemented for each feature
+
+- [ ] **File Explorer Implementation**:
+  - [ ] Details on how file system data will be fetched and cached
+  - [ ] Specification for file content display (syntax highlighting, encoding handling)
+  - [ ] Pagination or lazy loading strategy for large directories
+
+- [ ] **Agent Output Display Implementation**:
+  - [ ] Specification for how to handle different types of agent outputs (text, code, images)
+  - [ ] Details on output formatting and styling
+  - [ ] Scrolling or history management specification
+
+- [ ] **Backend Connection Management**:
+  - [ ] Details on connection persistence across app launches
+  - [ ] Specification for connection status indicators
+  - [ ] Retry mechanism details
+
+- [ ] **State Synchronization**:
+  - [ ] Specification for how to handle state synchronization between the app and backend
+  - [ ] Details on conflict resolution when state diverges
+  - [ ] Specification for handling stale state
+
+- [ ] **Error States and Recovery**:
+  - [ ] Defined error states for the application
+  - [ ] User feedback mechanisms for errors
+  - [ ] Recovery procedures for common failure scenarios
+
+- [ ] **Performance Considerations**:
+  - [ ] Specifications for handling large outputs from the agent
+  - [ ] Details on UI responsiveness during heavy operations
+  - [ ] Memory management strategy for long-running sessions
+
+- [ ] **Specific Swift Implementation Details**:
+  - [ ] Guidance on Swift concurrency approach (async/await, Combine, etc.)
+  - [ ] Details on property wrapper usage for state management
+  - [ ] Specification for dependency injection approach
+
+- [ ] **Event Handling Architecture**:
+  - [ ] Detailed specification for how events from the backend will be processed and routed to appropriate components
+  - [ ] Details on event prioritization and queueing


### PR DESCRIPTION
This PR adds a document that lists missing elements in the Mac app MVP specification. The document is formatted with checkboxes that can be tracked as items are addressed.