### PR TITLE
Add internal API naming convention documentation

### DIFF
--- a/.openhands/microagents/mac_app_code_exploration_findings.md
+++ b/.openhands/microagents/mac_app_code_exploration_findings.md
@@ -351,10 +351,10 @@ To run the command `ls -l /workspace`, send the following `oh_action` message:
 
 For clarity within the Mac app codebase, we'll use more descriptive internal terminology while maintaining compatibility with backend events:
 
-| API Event Name | Internal Term | Description                               |
-|----------------|---------------|-------------------------------------------|
-| `oh_action`    | `userAction`  | User-initiated commands sent to backend   |
-| `oh_event`     | `oh_event`    | All events received from backend          |
+| API Event Name | Internal Term    | Description                               |
+|----------------|------------------|-------------------------------------------|
+| `oh_action`    | `userAction`     | User-initiated commands sent to backend   |
+| `oh_event`     | `oh_event`       | All events received from backend          |
 
 Implementation example:
 ```swift

--- a/.openhands/microagents/what_is_missing.md
+++ b/.openhands/microagents/what_is_missing.md
@@ -1,0 +1,55 @@
+# Missing Elements in Mac App MVP Specification
+
+This document outlines specific technical gaps in the current Mac app MVP specification that need to be addressed for a complete implementation guide.
+
+## Technical Implementation Details
+
+- [ ] **Socket.IO Implementation Details**:
+  - [ ] Specific implementation details for handling Socket.IO connections
+  - [ ] Reconnection strategy when connection is lost
+  - [ ] Error handling for Socket.IO events
+  - [ ] Event queuing during disconnections
+
+- [ ] **UI Component Architecture**:
+  - [ ] Detailed breakdown of UI components and their relationships
+  - [ ] View hierarchy and navigation flow
+  - [ ] Specification for how the MVVM pattern should be implemented for each feature
+
+- [ ] **File Explorer Implementation**:
+  - [ ] Details on how file system data will be fetched and cached
+  - [ ] Specification for file content display (syntax highlighting, encoding handling)
+  - [ ] Pagination or lazy loading strategy for large directories
+
+- [ ] **Agent Output Display Implementation**:
+  - [ ] Specification for how to handle different types of agent outputs (text, code, images)
+  - [ ] Details on output formatting and styling
+  - [ ] Scrolling or history management specification
+
+- [ ] **Backend Connection Management**:
+  - [ ] Details on connection persistence across app launches
+  - [ ] Specification for connection status indicators
+  - [ ] Retry mechanism details
+
+- [ ] **State Synchronization**:
+  - [ ] Specification for how to handle state synchronization between the app and backend
+  - [ ] Details on conflict resolution when state diverges
+  - [ ] Specification for handling stale state
+
+- [ ] **Error States and Recovery**:
+  - [ ] Defined error states for the application
+  - [ ] User feedback mechanisms for errors
+  - [ ] Recovery procedures for common failure scenarios
+
+- [ ] **Performance Considerations**:
+  - [ ] Specifications for handling large outputs from the agent
+  - [ ] Details on UI responsiveness during heavy operations
+  - [ ] Memory management strategy for long-running sessions
+
+- [ ] **Specific Swift Implementation Details**:
+  - [ ] Guidance on Swift concurrency approach (async/await, Combine, etc.)
+  - [ ] Details on property wrapper usage for state management
+  - [ ] Specification for dependency injection approach
+
+- [ ] **Event Handling Architecture**:
+  - [ ] Detailed specification for how events from the backend will be processed and routed to appropriate components
+  - [ ] Details on event prioritization and queueing


### PR DESCRIPTION
This PR adds documentation for internal API naming conventions to improve code clarity while maintaining compatibility with backend events.