### PR TITLE
Rename swift-linux-install to swift-linux

### DIFF
--- a/.openhands/microagents/knowledge/swift-linux.md
+++ b/.openhands/microagents/knowledge/swift-linux.md
@@ -1,5 +1,5 @@
 ---
- name: swift-linux-install
+ name: swift-linux
  type: knowledge
  agent: CodeActAgent
  version: 1.0.0


### PR DESCRIPTION
This PR renames the Swift microagent from `swift-linux-install.md` to `swift-linux.md` and updates the microagent name in the frontmatter to match the filename. This ensures consistency between the filename and the microagent name.