### PR TITLE
Add GitHub workflow for files-to-prompt

### DIFF
--- a/.github/workflows/files-to-prompt.yml
+++ b/.github/workflows/files-to-prompt.yml
@@ -1,0 +1,109 @@
+name: Files to Prompt
+
+on:
+  workflow_dispatch:
+    inputs:
+      repo:
+        description: 'Repository name (owner/repo)'
+        required: true
+      branch:
+        description: 'Branch name'
+        required: true
+        default: 'main'
+      paths:
+        description: 'Comma-separated list of file or directory paths'
+        required: true
+      line_numbers:
+        description: 'Include line numbers'
+        required: false
+        default: 'false'
+        type: boolean
+      include_hidden:
+        description: 'Include hidden files'
+        required: false
+        default: 'false'
+        type: boolean
+      output_format:
+        description: 'Output format (default, markdown, cxml)'
+        required: false
+        default: 'markdown'
+        type: choice
+        options:
+          - default
+          - markdown
+          - cxml
+
+jobs:
+  generate-prompt:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          repository: ${{ github.event.inputs.repo }}
+          ref: ${{ github.event.inputs.branch }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      
+      - name: Install files-to-prompt
+        run: pip install files-to-prompt
+      
+      - name: Generate prompt
+        id: generate
+        run: |
+          # Convert comma-separated paths to space-separated
+          PATHS=$(echo "${{ github.event.inputs.paths }}" | tr ',' ' ')
+          
+          # Build command with options
+          CMD="files-to-prompt $PATHS"
+          
+          if [ "${{ github.event.inputs.line_numbers }}" == "true" ]; then
+            CMD="$CMD --line-numbers"
+          fi
+          
+          if [ "${{ github.event.inputs.include_hidden }}" == "true" ]; then
+            CMD="$CMD --include-hidden"
+          fi
+          
+          if [ "${{ github.event.inputs.output_format }}" == "markdown" ]; then
+            CMD="$CMD --markdown"
+          elif [ "${{ github.event.inputs.output_format }}" == "cxml" ]; then
+            CMD="$CMD --cxml"
+          fi
+          
+          # Create output directory
+          mkdir -p output
+          
+          # Run command and save output
+          echo "Running command: $CMD"
+          $CMD -o output/prompt.txt
+          
+          # Set output file extension based on format
+          if [ "${{ github.event.inputs.output_format }}" == "markdown" ]; then
+            mv output/prompt.txt output/prompt.md
+            echo "output_file=prompt.md" >> $GITHUB_OUTPUT
+          elif [ "${{ github.event.inputs.output_format }}" == "cxml" ]; then
+            mv output/prompt.txt output/prompt.xml
+            echo "output_file=prompt.xml" >> $GITHUB_OUTPUT
+          else
+            echo "output_file=prompt.txt" >> $GITHUB_OUTPUT
+          fi
+      
+      - name: Upload prompt as artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: files-to-prompt-output
+          path: output/${{ steps.generate.outputs.output_file }}
+          retention-days: 1
+      
+      - name: Generate response URL
+        run: |
+          echo "Your prompt has been generated and is available as an artifact in this workflow run."
+          echo "Download it from the 'Artifacts' section of this workflow run page."

--- a/.github/workflows/files-to-prompt.yml
+++ b/.github/workflows/files-to-prompt.yml
@@ -3,107 +3,128 @@ name: Files to Prompt
 on:
   workflow_dispatch:
     inputs:
-      repo:
-        description: 'Repository name (owner/repo)'
+      repository:
+        description: 'GitHub repository (format: owner/repo)'
         required: true
+        type: string
       branch:
         description: 'Branch name'
         required: true
         default: 'main'
+        type: string
       paths:
-        description: 'Comma-separated list of file or directory paths'
+        description: 'Comma-separated list of file/directory paths to include'
         required: true
-      line_numbers:
-        description: 'Include line numbers'
-        required: false
-        default: 'false'
-        type: boolean
+        type: string
       include_hidden:
         description: 'Include hidden files'
         required: false
-        default: 'false'
+        default: false
+        type: boolean
+      line_numbers:
+        description: 'Include line numbers'
+        required: false
+        default: false
         type: boolean
       output_format:
-        description: 'Output format (default, markdown, cxml)'
-        required: false
-        default: 'markdown'
+        description: 'Output format'
+        required: true
+        default: 'default'
         type: choice
         options:
           - default
           - markdown
           - cxml
+      ignore_patterns:
+        description: 'Comma-separated list of patterns to ignore'
+        required: false
+        type: string
+      ignore_gitignore:
+        description: 'Ignore .gitignore files'
+        required: false
+        default: false
+        type: boolean
 
 jobs:
-  generate-prompt:
+  process-files:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
-          repository: ${{ github.event.inputs.repo }}
+          repository: ${{ github.event.inputs.repository }}
           ref: ${{ github.event.inputs.branch }}
           token: ${{ secrets.GITHUB_TOKEN }}
-      
+          
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
-      
+          python-version: '3.11'
+          
       - name: Install files-to-prompt
-        run: pip install files-to-prompt
-      
-      - name: Generate prompt
-        id: generate
         run: |
-          # Convert comma-separated paths to space-separated
-          PATHS=$(echo "${{ github.event.inputs.paths }}" | tr ',' ' ')
+          python -m pip install --upgrade pip
+          pip install files-to-prompt
           
-          # Build command with options
-          CMD="files-to-prompt $PATHS"
+      - name: Process files
+        id: process-files
+        run: |
+          # Prepare command arguments
+          CMD_ARGS=""
           
-          if [ "${{ github.event.inputs.line_numbers }}" == "true" ]; then
-            CMD="$CMD --line-numbers"
+          # Add paths (split by comma and trim whitespace)
+          PATHS=$(echo "${{ github.event.inputs.paths }}" | tr ',' '\n' | xargs)
+          
+          # Add format option
+          if [ "${{ github.event.inputs.output_format }}" = "markdown" ]; then
+            CMD_ARGS="$CMD_ARGS --markdown"
+          elif [ "${{ github.event.inputs.output_format }}" = "cxml" ]; then
+            CMD_ARGS="$CMD_ARGS --cxml"
           fi
           
-          if [ "${{ github.event.inputs.include_hidden }}" == "true" ]; then
-            CMD="$CMD --include-hidden"
+          # Add line numbers option
+          if [ "${{ github.event.inputs.line_numbers }}" = "true" ]; then
+            CMD_ARGS="$CMD_ARGS --line-numbers"
           fi
           
-          if [ "${{ github.event.inputs.output_format }}" == "markdown" ]; then
-            CMD="$CMD --markdown"
-          elif [ "${{ github.event.inputs.output_format }}" == "cxml" ]; then
-            CMD="$CMD --cxml"
+          # Add include hidden option
+          if [ "${{ github.event.inputs.include_hidden }}" = "true" ]; then
+            CMD_ARGS="$CMD_ARGS --include-hidden"
+          fi
+          
+          # Add ignore patterns (split by comma and trim whitespace)
+          if [ -n "${{ github.event.inputs.ignore_patterns }}" ]; then
+            IGNORE_PATTERNS=$(echo "${{ github.event.inputs.ignore_patterns }}" | tr ',' '\n' | xargs -I{} echo "--ignore \"{}\"")
+            CMD_ARGS="$CMD_ARGS $IGNORE_PATTERNS"
+          fi
+          
+          # Add ignore gitignore option
+          if [ "${{ github.event.inputs.ignore_gitignore }}" = "true" ]; then
+            CMD_ARGS="$CMD_ARGS --ignore-gitignore"
           fi
           
           # Create output directory
           mkdir -p output
           
-          # Run command and save output
-          echo "Running command: $CMD"
-          $CMD -o output/prompt.txt
+          # Run files-to-prompt and save output
+          echo "Running: files-to-prompt $PATHS $CMD_ARGS -o output/prompt.txt"
+          files-to-prompt $PATHS $CMD_ARGS -o output/prompt.txt
           
-          # Set output file extension based on format
-          if [ "${{ github.event.inputs.output_format }}" == "markdown" ]; then
-            mv output/prompt.txt output/prompt.md
-            echo "output_file=prompt.md" >> $GITHUB_OUTPUT
-          elif [ "${{ github.event.inputs.output_format }}" == "cxml" ]; then
-            mv output/prompt.txt output/prompt.xml
-            echo "output_file=prompt.xml" >> $GITHUB_OUTPUT
-          else
-            echo "output_file=prompt.txt" >> $GITHUB_OUTPUT
-          fi
-      
-      - name: Upload prompt as artifact
-        uses: actions/upload-artifact@v3
+          # Create metadata file
+          cat > output/metadata.json << EOF
+          {
+            "repository": "${{ github.event.inputs.repository }}",
+            "branch": "${{ github.event.inputs.branch }}",
+            "paths": "${{ github.event.inputs.paths }}",
+            "format": "${{ github.event.inputs.output_format }}",
+            "timestamp": "$(date -u +"%Y-%m-%dT%H:%M:%SZ")",
+            "generated_by": "files-to-prompt GitHub Action"
+          }
+          EOF
+          
+      - name: Upload output as artifact
+        uses: actions/upload-artifact@v4
         with:
           name: files-to-prompt-output
-          path: output/${{ steps.generate.outputs.output_file }}
-          retention-days: 1
-      
-      - name: Generate response URL
-        run: |
-          echo "Your prompt has been generated and is available as an artifact in this workflow run."
-          echo "Download it from the 'Artifacts' section of this workflow run page."
+          path: output/
+          retention-days: 7

--- a/README.md
+++ b/README.md
@@ -1,1 +1,68 @@
-# microplay
+# Files to Prompt GitHub Interface
+
+This repository provides a GitHub Pages interface for [simonw/files-to-prompt](https://github.com/simonw/files-to-prompt), a tool that concatenates files from a repository into a single prompt for use with LLMs.
+
+## Features
+
+- Browse public GitHub repositories and select files/directories
+- Generate prompts in different formats (plain text, Markdown, Claude XML)
+- Process files locally in the browser or via GitHub Actions workflow
+- No GitHub token required for public repositories when using the GitHub workflow
+
+## How to Use
+
+### Option 1: GitHub Pages Interface with Local Processing
+
+1. Visit the GitHub Pages site
+2. Enter the repository owner and name
+3. Provide a GitHub token (required for local processing)
+4. Browse the repository and select files/directories
+5. Configure output options
+6. Click "Generate Prompt"
+7. Copy the generated prompt to your clipboard
+
+### Option 2: GitHub Pages Interface with GitHub Workflow
+
+1. Visit the GitHub Pages site
+2. Enter the repository owner and name
+3. Browse the repository and select files/directories
+4. Configure output options
+5. Click "Generate Prompt"
+6. Follow the instructions to trigger the GitHub workflow
+7. Download the generated prompt from the workflow artifacts
+
+## GitHub Workflow
+
+The repository includes a GitHub workflow that can be triggered manually to generate prompts. The workflow:
+
+1. Checks out the specified repository
+2. Installs the files-to-prompt tool
+3. Runs the tool with the specified options
+4. Uploads the generated prompt as a workflow artifact
+
+## Setup
+
+To set up this interface for your own use:
+
+1. Fork this repository
+2. Enable GitHub Pages for the repository
+3. The interface will be available at `https://[your-username].github.io/[repo-name]/`
+
+## Local Development
+
+To run the interface locally:
+
+```bash
+# Clone the repository
+git clone https://github.com/[your-username]/[repo-name].git
+cd [repo-name]
+
+# Serve the files using a local web server
+python -m http.server
+```
+
+Then visit `http://localhost:8000` in your browser.
+
+## License
+
+This project is licensed under the MIT License - see the LICENSE file for details.

--- a/README.md
+++ b/README.md
@@ -1,67 +1,78 @@
-# Files to Prompt GitHub Interface
+# Files-to-Prompt GitHub Interface
 
-This repository provides a GitHub Pages interface for [simonw/files-to-prompt](https://github.com/simonw/files-to-prompt), a tool that concatenates files from a repository into a single prompt for use with LLMs.
+This repository provides a GitHub Pages interface for [simonw/files-to-prompt](https://github.com/simonw/files-to-prompt), a tool that concatenates a directory full of files into a single prompt for use with LLMs.
 
 ## Features
 
-- Browse public GitHub repositories and select files/directories
-- Generate prompts in different formats (plain text, Markdown, Claude XML)
-- Process files locally in the browser or via GitHub Actions workflow
-- No GitHub token required for public repositories when using the GitHub workflow
+- Browse GitHub repositories and select files/directories to include in your prompt
+- Process files locally in the browser or use a GitHub workflow
+- Support for all files-to-prompt options:
+  - Line numbers
+  - Hidden files
+  - Output formats (default, markdown, Claude XML)
+  - Ignore patterns
+  - .gitignore handling
 
-## How to Use
+## Usage
 
-### Option 1: GitHub Pages Interface with Local Processing
+### Local Processing
 
-1. Visit the GitHub Pages site
-2. Enter the repository owner and name
-3. Provide a GitHub token (required for local processing)
-4. Browse the repository and select files/directories
-5. Configure output options
+1. Enter the repository owner and name
+2. Enter a GitHub token with `repo` scope (required for accessing repository contents)
+3. Click "Load Repository"
+4. Browse the repository and select files/directories to include
+5. Configure options (line numbers, output format, etc.)
 6. Click "Generate Prompt"
-7. Copy the generated prompt to your clipboard
+7. Copy or download the generated prompt
 
-### Option 2: GitHub Pages Interface with GitHub Workflow
+### GitHub Workflow
 
-1. Visit the GitHub Pages site
-2. Enter the repository owner and name
-3. Browse the repository and select files/directories
-4. Configure output options
-5. Click "Generate Prompt"
-6. Follow the instructions to trigger the GitHub workflow
-7. Download the generated prompt from the workflow artifacts
+For larger repositories or when you don't want to use a personal access token, you can use the GitHub workflow option:
+
+1. Enter the repository owner and name
+2. Click "Load Repository"
+3. Browse the repository and select files/directories to include
+4. Configure options (line numbers, output format, etc.)
+5. Uncheck "Process files locally"
+6. Click "Generate Prompt"
+7. Follow the instructions to trigger the GitHub workflow
+8. Download the generated prompt from the workflow artifacts
 
 ## GitHub Workflow
 
-The repository includes a GitHub workflow that can be triggered manually to generate prompts. The workflow:
+The repository includes a GitHub workflow file (`.github/workflows/files-to-prompt.yml`) that can be triggered manually to process files from a repository and generate a prompt.
 
-1. Checks out the specified repository
-2. Installs the files-to-prompt tool
-3. Runs the tool with the specified options
-4. Uploads the generated prompt as a workflow artifact
+### Workflow Inputs
 
-## Setup
+- `repository`: GitHub repository (format: owner/repo)
+- `branch`: Branch name
+- `paths`: Comma-separated list of file/directory paths to include
+- `include_hidden`: Include hidden files
+- `line_numbers`: Include line numbers
+- `output_format`: Output format (default, markdown, cxml)
+- `ignore_patterns`: Comma-separated list of patterns to ignore
+- `ignore_gitignore`: Ignore .gitignore files
 
-To set up this interface for your own use:
+### Workflow Outputs
 
-1. Fork this repository
-2. Enable GitHub Pages for the repository
-3. The interface will be available at `https://[your-username].github.io/[repo-name]/`
+The workflow produces an artifact containing:
+- `prompt.txt`: The generated prompt
+- `metadata.json`: Metadata about the generation process
 
-## Local Development
+## Security Considerations
 
-To run the interface locally:
+- GitHub tokens are stored only in your browser's local storage and are never sent to any server other than GitHub's API
+- When using the GitHub workflow option, no token is required for public repositories
+- The workflow runs in the context of the repository, so it can only access files that are part of the repository
 
-```bash
-# Clone the repository
-git clone https://github.com/[your-username]/[repo-name].git
-cd [repo-name]
+## Development
 
-# Serve the files using a local web server
-python -m http.server
-```
+To contribute to this project:
 
-Then visit `http://localhost:8000` in your browser.
+1. Clone the repository
+2. Make your changes
+3. Test locally using a web server (e.g., `python -m http.server`)
+4. Submit a pull request
 
 ## License
 

--- a/index.html
+++ b/index.html
@@ -207,7 +207,8 @@
   
   <div class="token-input">
     <h2>GitHub Authentication</h2>
-    <p>A GitHub token is required to access repository contents. This token is stored only in your browser and is never sent to our servers.</p>
+    <p>A GitHub token is required to access repository contents when using local processing. This token is stored only in your browser and is never sent to our servers.</p>
+    <p><strong>Note:</strong> If you're using the GitHub workflow option (default), a token is not required here as the workflow will use GitHub's built-in token.</p>
     <label for="github-token">GitHub Token (with repo scope):</label>
     <input type="password" id="github-token" placeholder="ghp_xxxxxxxxxxxxxxxxxxxx">
   </div>
@@ -295,14 +296,15 @@
       const repo = repoInput.value.trim();
       const branch = branchInput.value.trim() || 'main';
       const token = tokenInput.value.trim();
+      const isLocalProcessing = localProcessingCheckbox.checked;
       
       if (!owner || !repo) {
         alert('Please enter both owner and repository name');
         return;
       }
       
-      if (!token) {
-        alert('Please enter a GitHub token');
+      if (isLocalProcessing && !token) {
+        alert('Please enter a GitHub token when using local processing');
         return;
       }
       
@@ -325,14 +327,23 @@
       
       try {
         const url = `https://api.github.com/repos/${owner}/${repo}/contents/${path}?ref=${branch}`;
-        const response = await fetch(url, {
-          headers: {
-            'Authorization': `token ${token}`,
-            'Accept': 'application/vnd.github.v3+json'
-          }
-        });
+        
+        // Set up headers based on whether a token is provided
+        const headers = {
+          'Accept': 'application/vnd.github.v3+json'
+        };
+        
+        if (token) {
+          headers['Authorization'] = `token ${token}`;
+        }
+        
+        const response = await fetch(url, { headers });
         
         if (!response.ok) {
+          // If we get a 403 and no token was provided, suggest using a token
+          if (response.status === 403 && !token) {
+            throw new Error('Rate limit exceeded. Please provide a GitHub token for higher rate limits.');
+          }
           throw new Error(`Failed to fetch repository contents: ${response.statusText}`);
         }
         
@@ -568,14 +579,23 @@
         }
         
         const url = `https://api.github.com/repos/${owner}/${repo}/contents/${path}?ref=${branch}`;
-        const response = await fetch(url, {
-          headers: {
-            'Authorization': `token ${token}`,
-            'Accept': 'application/vnd.github.v3+json'
-          }
-        });
+        
+        // Set up headers based on whether a token is provided
+        const headers = {
+          'Accept': 'application/vnd.github.v3+json'
+        };
+        
+        if (token) {
+          headers['Authorization'] = `token ${token}`;
+        }
+        
+        const response = await fetch(url, { headers });
         
         if (!response.ok) {
+          // If we get a 403 and no token was provided, suggest using a token
+          if (response.status === 403 && !token) {
+            throw new Error('Rate limit exceeded. Please provide a GitHub token for higher rate limits.');
+          }
           throw new Error(`Failed to fetch file content: ${response.statusText}`);
         }
         
@@ -740,14 +760,43 @@
           outputText.textContent = output;
           outputContainer.style.display = 'block';
         } else {
-          // Use GitHub workflow (this is a placeholder - in a real implementation, you would trigger a GitHub workflow)
-          alert('GitHub workflow integration is not implemented in this demo. Please use local processing instead.');
+          // Use GitHub workflow
+          const fullRepo = `${owner}/${repo}`;
+          const pathsArray = Array.from(selectedPaths);
+          const pathsString = pathsArray.join(',');
+          const lineNumbers = document.getElementById('line-numbers').checked;
+          const includeHidden = document.getElementById('include-hidden').checked;
+          const outputFormat = document.getElementById('output-format').value;
           
-          // For demonstration purposes, we'll still process locally
-          const output = await processFilesLocally(owner, repo, branch, token);
+          // Create a link to the GitHub workflow dispatch page
+          const workflowUrl = `https://github.com/${owner}/microplay/actions/workflows/files-to-prompt.yml`;
           
-          // Display output
-          outputText.textContent = output;
+          // Create a message with instructions
+          const message = `
+            <div class="success">
+              <h3>GitHub Workflow</h3>
+              <p>To run the files-to-prompt tool via GitHub Actions, please follow these steps:</p>
+              <ol>
+                <li>Go to the <a href="${workflowUrl}" target="_blank">Files to Prompt workflow page</a></li>
+                <li>Click "Run workflow"</li>
+                <li>Enter the following values:</li>
+                <ul>
+                  <li>Repository name: <strong>${fullRepo}</strong></li>
+                  <li>Branch name: <strong>${branch}</strong></li>
+                  <li>Paths: <strong>${pathsString}</strong></li>
+                  <li>Line numbers: <strong>${lineNumbers}</strong></li>
+                  <li>Include hidden files: <strong>${includeHidden}</strong></li>
+                  <li>Output format: <strong>${outputFormat}</strong></li>
+                </ul>
+                <li>Click "Run workflow"</li>
+                <li>Wait for the workflow to complete</li>
+                <li>Download the artifact from the workflow run page</li>
+              </ol>
+            </div>
+          `;
+          
+          // Display the message
+          outputText.innerHTML = message;
           outputContainer.style.display = 'block';
         }
       } catch (error) {

--- a/index.html
+++ b/index.html
@@ -207,8 +207,8 @@
   
   <div class="token-input">
     <h2>GitHub Authentication</h2>
-    <p>A GitHub token is required to access repository contents when using local processing. This token is stored only in your browser and is never sent to our servers.</p>
-    <p><strong>Note:</strong> If you're using the GitHub workflow option (default), a token is not required here as the workflow will use GitHub's built-in token.</p>
+    <p>A GitHub token is required to access repository contents. This token is stored only in your browser and is never sent to our servers.</p>
+    <p><strong>Note:</strong> For public repositories, a token is only required when using local processing. The GitHub workflow can process public repositories without a token.</p>
     <label for="github-token">GitHub Token (with repo scope):</label>
     <input type="password" id="github-token" placeholder="ghp_xxxxxxxxxxxxxxxxxxxx">
   </div>
@@ -230,7 +230,25 @@
       </select>
     </label>
     <label>
-      <input type="checkbox" id="local-processing"> Process files locally (no GitHub workflow)
+      <input type="checkbox" id="local-processing" checked> Process files locally
+    </label>
+    <div id="workflow-info" style="display: none; margin-top: 15px; padding: 10px; background-color: #f0f7ff; border-radius: 4px;">
+      <h3>GitHub Workflow</h3>
+      <p>When using the GitHub workflow option:</p>
+      <ol>
+        <li>The workflow will be triggered in the repository.</li>
+        <li>Files will be processed on GitHub's servers.</li>
+        <li>Results will be available as a downloadable artifact.</li>
+        <li>You'll need to visit the Actions tab in the repository to download the results.</li>
+      </ol>
+      <p><strong>Note:</strong> This requires that you have write access to the repository.</p>
+    </div>
+    <label id="ignore-patterns-container" style="margin-top: 10px;">
+      Ignore patterns (comma-separated):
+      <input type="text" id="ignore-patterns" placeholder="*.log, temp*">
+    </label>
+    <label>
+      <input type="checkbox" id="ignore-gitignore"> Ignore .gitignore files
     </label>
   </div>
   
@@ -280,6 +298,9 @@
     const selectAllCheckbox = document.getElementById('select-all-checkbox');
     const generateBtn = document.getElementById('generate-btn');
     const localProcessingCheckbox = document.getElementById('local-processing');
+    const workflowInfoDiv = document.getElementById('workflow-info');
+    const ignorePatterns = document.getElementById('ignore-patterns');
+    const ignoreGitignore = document.getElementById('ignore-gitignore');
     const outputContainer = document.getElementById('output-container');
     const outputText = document.getElementById('output-text');
     const copyOutputBtn = document.getElementById('copy-output-btn');
@@ -290,21 +311,35 @@
     let selectedPaths = new Set();
     let fileCache = {};
     
+    // Toggle workflow info based on local processing checkbox
+    localProcessingCheckbox.addEventListener('change', () => {
+      workflowInfoDiv.style.display = localProcessingCheckbox.checked ? 'none' : 'block';
+      
+      // Update token requirement message
+      const tokenRequiredMsg = document.querySelector('.token-input p:nth-child(2)');
+      if (tokenRequiredMsg) {
+        if (localProcessingCheckbox.checked) {
+          tokenRequiredMsg.innerHTML = '<strong>Note:</strong> For public repositories, a token is only required when using local processing. The GitHub workflow can process public repositories without a token.';
+        } else {
+          tokenRequiredMsg.innerHTML = '<strong>Note:</strong> No token is required for public repositories when using the GitHub workflow. You only need a token if you have write access to the repository to trigger the workflow.';
+        }
+      }
+    });
+    
     // Load repository
     loadRepoBtn.addEventListener('click', () => {
       const owner = ownerInput.value.trim();
       const repo = repoInput.value.trim();
       const branch = branchInput.value.trim() || 'main';
       const token = tokenInput.value.trim();
-      const isLocalProcessing = localProcessingCheckbox.checked;
       
       if (!owner || !repo) {
         alert('Please enter both owner and repository name');
         return;
       }
       
-      if (isLocalProcessing && !token) {
-        alert('Please enter a GitHub token when using local processing');
+      if (localProcessingCheckbox.checked && !token) {
+        alert('Please enter a GitHub token for local processing');
         return;
       }
       
@@ -327,23 +362,14 @@
       
       try {
         const url = `https://api.github.com/repos/${owner}/${repo}/contents/${path}?ref=${branch}`;
-        
-        // Set up headers based on whether a token is provided
-        const headers = {
-          'Accept': 'application/vnd.github.v3+json'
-        };
-        
-        if (token) {
-          headers['Authorization'] = `token ${token}`;
-        }
-        
-        const response = await fetch(url, { headers });
+        const response = await fetch(url, {
+          headers: {
+            'Authorization': `token ${token}`,
+            'Accept': 'application/vnd.github.v3+json'
+          }
+        });
         
         if (!response.ok) {
-          // If we get a 403 and no token was provided, suggest using a token
-          if (response.status === 403 && !token) {
-            throw new Error('Rate limit exceeded. Please provide a GitHub token for higher rate limits.');
-          }
           throw new Error(`Failed to fetch repository contents: ${response.statusText}`);
         }
         
@@ -579,23 +605,14 @@
         }
         
         const url = `https://api.github.com/repos/${owner}/${repo}/contents/${path}?ref=${branch}`;
-        
-        // Set up headers based on whether a token is provided
-        const headers = {
-          'Accept': 'application/vnd.github.v3+json'
-        };
-        
-        if (token) {
-          headers['Authorization'] = `token ${token}`;
-        }
-        
-        const response = await fetch(url, { headers });
+        const response = await fetch(url, {
+          headers: {
+            'Authorization': `token ${token}`,
+            'Accept': 'application/vnd.github.v3+json'
+          }
+        });
         
         if (!response.ok) {
-          // If we get a 403 and no token was provided, suggest using a token
-          if (response.status === 403 && !token) {
-            throw new Error('Rate limit exceeded. Please provide a GitHub token for higher rate limits.');
-          }
           throw new Error(`Failed to fetch file content: ${response.statusText}`);
         }
         
@@ -761,42 +778,45 @@
           outputContainer.style.display = 'block';
         } else {
           // Use GitHub workflow
-          const fullRepo = `${owner}/${repo}`;
-          const pathsArray = Array.from(selectedPaths);
-          const pathsString = pathsArray.join(',');
+          const repoFullName = `${owner}/${repo}`;
+          const pathsList = Array.from(selectedPaths).join(',');
+          const outputFormat = document.getElementById('output-format').value;
           const lineNumbers = document.getElementById('line-numbers').checked;
           const includeHidden = document.getElementById('include-hidden').checked;
-          const outputFormat = document.getElementById('output-format').value;
+          const ignorePatternsList = ignorePatterns.value.trim();
+          const ignoreGitignoreValue = ignoreGitignore.checked;
           
-          // Create a link to the GitHub workflow dispatch page
-          const workflowUrl = `https://github.com/${owner}/microplay/actions/workflows/files-to-prompt.yml`;
+          // Create workflow URL
+          const workflowUrl = `https://github.com/${repoFullName}/actions/workflows/files-to-prompt.yml`;
           
-          // Create a message with instructions
-          const message = `
-            <div class="success">
-              <h3>GitHub Workflow</h3>
-              <p>To run the files-to-prompt tool via GitHub Actions, please follow these steps:</p>
-              <ol>
-                <li>Go to the <a href="${workflowUrl}" target="_blank">Files to Prompt workflow page</a></li>
-                <li>Click "Run workflow"</li>
-                <li>Enter the following values:</li>
-                <ul>
-                  <li>Repository name: <strong>${fullRepo}</strong></li>
-                  <li>Branch name: <strong>${branch}</strong></li>
-                  <li>Paths: <strong>${pathsString}</strong></li>
-                  <li>Line numbers: <strong>${lineNumbers}</strong></li>
-                  <li>Include hidden files: <strong>${includeHidden}</strong></li>
-                  <li>Output format: <strong>${outputFormat}</strong></li>
-                </ul>
-                <li>Click "Run workflow"</li>
-                <li>Wait for the workflow to complete</li>
-                <li>Download the artifact from the workflow run page</li>
-              </ol>
-            </div>
-          `;
+          // Show instructions
+          outputText.innerHTML = `
+<h3>GitHub Workflow Instructions</h3>
+
+<p>To run the files-to-prompt workflow:</p>
+
+<ol>
+  <li>Visit the <a href="${workflowUrl}" target="_blank">GitHub Actions workflow page</a></li>
+  <li>Click on "Run workflow"</li>
+  <li>Enter the following parameters:</li>
+</ol>
+
+<pre>
+Repository: ${repoFullName}
+Branch: ${branch}
+Paths: ${pathsList}
+Include hidden files: ${includeHidden}
+Line numbers: ${lineNumbers}
+Output format: ${outputFormat}
+${ignorePatternsList ? `Ignore patterns: ${ignorePatternsList}` : ''}
+${ignoreGitignoreValue ? 'Ignore .gitignore files: true' : ''}
+</pre>
+
+<p>After the workflow completes, you can download the generated prompt from the workflow run page.</p>
+
+<p><strong>Note:</strong> If this is the first time running the workflow, you may need to enable GitHub Actions for this repository.</p>
+`;
           
-          // Display the message
-          outputText.innerHTML = message;
           outputContainer.style.display = 'block';
         }
       } catch (error) {

--- a/index.html
+++ b/index.html
@@ -1,0 +1,818 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Files to Prompt Selector</title>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <style>
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+      max-width: 1200px;
+      margin: 0 auto;
+      padding: 20px;
+      line-height: 1.5;
+    }
+    
+    h1, h2, h3 {
+      color: #24292e;
+    }
+    
+    .file-tree {
+      list-style-type: none;
+      padding-left: 20px;
+      margin: 0;
+    }
+    
+    .file-tree-root {
+      padding-left: 0;
+    }
+    
+    .directory-label {
+      cursor: pointer;
+      user-select: none;
+      display: inline-block;
+      padding: 3px;
+      border-radius: 3px;
+    }
+    
+    .directory-label:hover {
+      background-color: #f0f0f0;
+    }
+    
+    .file-label {
+      display: inline-block;
+      padding: 3px;
+      border-radius: 3px;
+    }
+    
+    .selected {
+      background-color: #e6f7ff;
+    }
+    
+    .options-panel {
+      background-color: #f8f8f8;
+      padding: 15px;
+      border-radius: 5px;
+      margin: 20px 0;
+    }
+    
+    .options-panel label {
+      display: block;
+      margin-bottom: 10px;
+    }
+    
+    button {
+      background-color: #2ea44f;
+      color: white;
+      border: none;
+      padding: 10px 16px;
+      border-radius: 6px;
+      font-size: 14px;
+      font-weight: 500;
+      cursor: pointer;
+      margin-top: 10px;
+    }
+    
+    button:hover {
+      background-color: #2c974b;
+    }
+    
+    button:disabled {
+      background-color: #94d3a2;
+      cursor: not-allowed;
+    }
+    
+    .loading {
+      color: #666;
+      font-style: italic;
+    }
+    
+    .breadcrumb {
+      margin-bottom: 15px;
+      padding: 8px;
+      background-color: #f8f8f8;
+      border-radius: 4px;
+    }
+    
+    .breadcrumb a {
+      color: #0366d6;
+      text-decoration: none;
+    }
+    
+    .breadcrumb a:hover {
+      text-decoration: underline;
+    }
+    
+    .path-display {
+      margin-top: 20px;
+      padding: 10px;
+      background-color: #f0f0f0;
+      border-radius: 4px;
+      max-height: 200px;
+      overflow-y: auto;
+    }
+    
+    .select-all {
+      margin-bottom: 10px;
+    }
+    
+    .error {
+      color: #cb2431;
+      background-color: #ffeef0;
+      padding: 10px;
+      border-radius: 4px;
+      margin: 10px 0;
+    }
+    
+    .success {
+      color: #22863a;
+      background-color: #f0fff4;
+      padding: 10px;
+      border-radius: 4px;
+      margin: 10px 0;
+    }
+    
+    .token-input {
+      margin-top: 20px;
+      padding: 15px;
+      background-color: #f8f8f8;
+      border-radius: 5px;
+    }
+    
+    .token-input input {
+      width: 100%;
+      padding: 8px;
+      margin-top: 5px;
+      border: 1px solid #ddd;
+      border-radius: 4px;
+    }
+    
+    .output-container {
+      margin-top: 20px;
+      padding: 15px;
+      background-color: #f8f8f8;
+      border-radius: 5px;
+      display: none;
+    }
+    
+    .output-text {
+      white-space: pre-wrap;
+      background-color: #f6f8fa;
+      padding: 10px;
+      border-radius: 4px;
+      border: 1px solid #ddd;
+      max-height: 400px;
+      overflow-y: auto;
+    }
+    
+    .copy-button {
+      background-color: #0366d6;
+      margin-left: 10px;
+    }
+    
+    .copy-button:hover {
+      background-color: #0256b9;
+    }
+    
+    .repo-selector {
+      margin-bottom: 20px;
+    }
+    
+    .repo-selector input, .repo-selector select {
+      padding: 8px;
+      margin-right: 10px;
+      border: 1px solid #ddd;
+      border-radius: 4px;
+    }
+  </style>
+</head>
+<body>
+  <h1>Files to Prompt Selector</h1>
+  
+  <div class="repo-selector">
+    <h2>Repository Information</h2>
+    <div>
+      <label for="owner">Owner:</label>
+      <input type="text" id="owner" placeholder="GitHub username or organization">
+      
+      <label for="repo">Repository:</label>
+      <input type="text" id="repo" placeholder="Repository name">
+      
+      <label for="branch">Branch:</label>
+      <input type="text" id="branch" placeholder="main" value="main">
+      
+      <button id="load-repo-btn">Load Repository</button>
+    </div>
+  </div>
+  
+  <div class="token-input">
+    <h2>GitHub Authentication</h2>
+    <p>A GitHub token is required to access repository contents. This token is stored only in your browser and is never sent to our servers.</p>
+    <label for="github-token">GitHub Token (with repo scope):</label>
+    <input type="password" id="github-token" placeholder="ghp_xxxxxxxxxxxxxxxxxxxx">
+  </div>
+  
+  <div class="options-panel">
+    <h2>Options</h2>
+    <label>
+      <input type="checkbox" id="line-numbers"> Include line numbers
+    </label>
+    <label>
+      <input type="checkbox" id="include-hidden"> Include hidden files
+    </label>
+    <label>
+      Output format:
+      <select id="output-format">
+        <option value="markdown">Markdown</option>
+        <option value="cxml">Claude XML</option>
+        <option value="default">Default (plain text)</option>
+      </select>
+    </label>
+    <label>
+      <input type="checkbox" id="local-processing"> Process files locally (no GitHub workflow)
+    </label>
+  </div>
+  
+  <div id="repository-browser" style="display: none;">
+    <div class="breadcrumb" id="breadcrumb">
+      <span>Repository: </span><a href="#" data-path="">root</a>
+    </div>
+    
+    <div class="select-all">
+      <label>
+        <input type="checkbox" id="select-all-checkbox"> Select all in current view
+      </label>
+    </div>
+    
+    <div id="file-tree-container">
+      <p class="loading">Loading repository structure...</p>
+    </div>
+    
+    <div class="path-display">
+      <h3>Selected Paths:</h3>
+      <div id="selected-paths"></div>
+    </div>
+    
+    <button id="generate-btn" disabled>Generate Prompt</button>
+  </div>
+  
+  <div id="output-container" class="output-container">
+    <h2>Generated Prompt</h2>
+    <div class="output-actions">
+      <button id="copy-output-btn" class="copy-button">Copy to Clipboard</button>
+      <button id="download-output-btn" class="copy-button">Download as File</button>
+    </div>
+    <pre id="output-text" class="output-text"></pre>
+  </div>
+  
+  <script>
+    // DOM Elements
+    const ownerInput = document.getElementById('owner');
+    const repoInput = document.getElementById('repo');
+    const branchInput = document.getElementById('branch');
+    const tokenInput = document.getElementById('github-token');
+    const loadRepoBtn = document.getElementById('load-repo-btn');
+    const repositoryBrowser = document.getElementById('repository-browser');
+    const fileTreeContainer = document.getElementById('file-tree-container');
+    const breadcrumbContainer = document.getElementById('breadcrumb');
+    const selectedPathsDisplay = document.getElementById('selected-paths');
+    const selectAllCheckbox = document.getElementById('select-all-checkbox');
+    const generateBtn = document.getElementById('generate-btn');
+    const localProcessingCheckbox = document.getElementById('local-processing');
+    const outputContainer = document.getElementById('output-container');
+    const outputText = document.getElementById('output-text');
+    const copyOutputBtn = document.getElementById('copy-output-btn');
+    const downloadOutputBtn = document.getElementById('download-output-btn');
+    
+    // State
+    let currentPath = '';
+    let selectedPaths = new Set();
+    let fileCache = {};
+    
+    // Load repository
+    loadRepoBtn.addEventListener('click', () => {
+      const owner = ownerInput.value.trim();
+      const repo = repoInput.value.trim();
+      const branch = branchInput.value.trim() || 'main';
+      const token = tokenInput.value.trim();
+      
+      if (!owner || !repo) {
+        alert('Please enter both owner and repository name');
+        return;
+      }
+      
+      if (!token) {
+        alert('Please enter a GitHub token');
+        return;
+      }
+      
+      // Reset state
+      currentPath = '';
+      selectedPaths.clear();
+      fileCache = {};
+      
+      // Show repository browser
+      repositoryBrowser.style.display = 'block';
+      
+      // Load repository contents
+      fetchRepoContents(owner, repo, branch, token, '');
+    });
+    
+    // Fetch repository contents for a specific path
+    async function fetchRepoContents(owner, repo, branch, token, path = '') {
+      fileTreeContainer.innerHTML = '<p class="loading">Loading repository structure...</p>';
+      generateBtn.disabled = true;
+      
+      try {
+        const url = `https://api.github.com/repos/${owner}/${repo}/contents/${path}?ref=${branch}`;
+        const response = await fetch(url, {
+          headers: {
+            'Authorization': `token ${token}`,
+            'Accept': 'application/vnd.github.v3+json'
+          }
+        });
+        
+        if (!response.ok) {
+          throw new Error(`Failed to fetch repository contents: ${response.statusText}`);
+        }
+        
+        const data = await response.json();
+        
+        // Sort: directories first, then files, both alphabetically
+        const sortedData = Array.isArray(data) ? 
+          [...data].sort((a, b) => {
+            if (a.type !== b.type) {
+              return a.type === 'dir' ? -1 : 1;
+            }
+            return a.name.localeCompare(b.name);
+          }) : data;
+        
+        renderFileTree(owner, repo, branch, token, sortedData, path);
+        updateBreadcrumb(owner, repo, branch, token, path);
+        generateBtn.disabled = selectedPaths.size === 0;
+        return sortedData;
+      } catch (error) {
+        console.error('Error fetching repository contents:', error);
+        fileTreeContainer.innerHTML = `<p class="error">Error loading repository structure: ${error.message}</p>`;
+        return [];
+      }
+    }
+    
+    // Render the file tree
+    function renderFileTree(owner, repo, branch, token, items, currentPath) {
+      fileTreeContainer.innerHTML = '';
+      
+      if (!Array.isArray(items)) {
+        fileTreeContainer.innerHTML = '<p>This is a file, not a directory.</p>';
+        return;
+      }
+      
+      if (items.length === 0) {
+        fileTreeContainer.innerHTML = '<p>This directory is empty.</p>';
+        return;
+      }
+      
+      const ul = document.createElement('ul');
+      ul.className = 'file-tree file-tree-root';
+      
+      items.forEach(item => {
+        const li = document.createElement('li');
+        
+        const itemPath = currentPath ? `${currentPath}/${item.name}` : item.name;
+        
+        if (item.type === 'dir') {
+          // Directory
+          const checkbox = document.createElement('input');
+          checkbox.type = 'checkbox';
+          checkbox.dataset.path = itemPath;
+          checkbox.checked = selectedPaths.has(itemPath);
+          checkbox.addEventListener('change', (e) => {
+            if (e.target.checked) {
+              selectedPaths.add(itemPath);
+            } else {
+              selectedPaths.delete(itemPath);
+            }
+            updateSelectedPathsDisplay();
+            generateBtn.disabled = selectedPaths.size === 0;
+          });
+          
+          const dirSpan = document.createElement('span');
+          dirSpan.className = 'directory-label';
+          dirSpan.innerHTML = `📁 ${item.name}`;
+          dirSpan.addEventListener('click', () => navigateTo(owner, repo, branch, token, itemPath));
+          
+          li.appendChild(checkbox);
+          li.appendChild(dirSpan);
+        } else {
+          // File
+          const checkbox = document.createElement('input');
+          checkbox.type = 'checkbox';
+          checkbox.dataset.path = itemPath;
+          checkbox.checked = selectedPaths.has(itemPath);
+          checkbox.addEventListener('change', (e) => {
+            if (e.target.checked) {
+              selectedPaths.add(itemPath);
+            } else {
+              selectedPaths.delete(itemPath);
+            }
+            updateSelectedPathsDisplay();
+            generateBtn.disabled = selectedPaths.size === 0;
+          });
+          
+          const fileSpan = document.createElement('span');
+          fileSpan.className = 'file-label';
+          fileSpan.innerHTML = `📄 ${item.name}`;
+          
+          li.appendChild(checkbox);
+          li.appendChild(fileSpan);
+        }
+        
+        ul.appendChild(li);
+      });
+      
+      fileTreeContainer.appendChild(ul);
+      
+      // Update select all checkbox state
+      updateSelectAllCheckbox();
+    }
+    
+    // Navigate to a specific path
+    function navigateTo(owner, repo, branch, token, path) {
+      currentPath = path;
+      fetchRepoContents(owner, repo, branch, token, path);
+    }
+    
+    // Update breadcrumb navigation
+    function updateBreadcrumb(owner, repo, branch, token, path) {
+      const parts = path.split('/').filter(Boolean);
+      
+      // Clear existing breadcrumb except for the root link
+      while (breadcrumbContainer.childNodes.length > 2) {
+        breadcrumbContainer.removeChild(breadcrumbContainer.lastChild);
+      }
+      
+      // Update root link
+      const rootLink = breadcrumbContainer.querySelector('a');
+      rootLink.dataset.path = '';
+      rootLink.addEventListener('click', (e) => {
+        e.preventDefault();
+        navigateTo(owner, repo, branch, token, '');
+      });
+      
+      // Add path parts
+      let currentPathPart = '';
+      parts.forEach((part, index) => {
+        breadcrumbContainer.appendChild(document.createTextNode(' / '));
+        
+        currentPathPart = currentPathPart ? `${currentPathPart}/${part}` : part;
+        
+        const link = document.createElement('a');
+        link.href = '#';
+        link.textContent = part;
+        link.dataset.path = currentPathPart;
+        
+        link.addEventListener('click', (e) => {
+          e.preventDefault();
+          navigateTo(owner, repo, branch, token, link.dataset.path);
+        });
+        
+        breadcrumbContainer.appendChild(link);
+      });
+    }
+    
+    // Update the display of selected paths
+    function updateSelectedPathsDisplay() {
+      selectedPathsDisplay.innerHTML = '';
+      
+      if (selectedPaths.size === 0) {
+        selectedPathsDisplay.textContent = 'No files or directories selected';
+        return;
+      }
+      
+      const ul = document.createElement('ul');
+      
+      Array.from(selectedPaths).sort().forEach(path => {
+        const li = document.createElement('li');
+        li.textContent = path;
+        
+        const removeBtn = document.createElement('button');
+        removeBtn.textContent = 'Remove';
+        removeBtn.style.marginLeft = '10px';
+        removeBtn.style.padding = '2px 5px';
+        removeBtn.style.fontSize = '12px';
+        
+        removeBtn.addEventListener('click', () => {
+          selectedPaths.delete(path);
+          updateSelectedPathsDisplay();
+          
+          // Update checkbox if it's visible in the current view
+          const checkbox = document.querySelector(`input[data-path="${path}"]`);
+          if (checkbox) {
+            checkbox.checked = false;
+          }
+          
+          updateSelectAllCheckbox();
+          generateBtn.disabled = selectedPaths.size === 0;
+        });
+        
+        li.appendChild(removeBtn);
+        ul.appendChild(li);
+      });
+      
+      selectedPathsDisplay.appendChild(ul);
+    }
+    
+    // Update the "select all" checkbox state
+    function updateSelectAllCheckbox() {
+      const checkboxes = document.querySelectorAll('#file-tree-container input[type="checkbox"]');
+      
+      if (checkboxes.length === 0) {
+        selectAllCheckbox.checked = false;
+        selectAllCheckbox.disabled = true;
+        return;
+      }
+      
+      selectAllCheckbox.disabled = false;
+      
+      const allChecked = Array.from(checkboxes).every(cb => cb.checked);
+      const someChecked = Array.from(checkboxes).some(cb => cb.checked);
+      
+      selectAllCheckbox.checked = allChecked;
+      selectAllCheckbox.indeterminate = someChecked && !allChecked;
+    }
+    
+    // Select all checkbox handler
+    selectAllCheckbox.addEventListener('change', (e) => {
+      const checkboxes = document.querySelectorAll('#file-tree-container input[type="checkbox"]');
+      
+      checkboxes.forEach(checkbox => {
+        checkbox.checked = e.target.checked;
+        
+        if (e.target.checked) {
+          selectedPaths.add(checkbox.dataset.path);
+        } else {
+          selectedPaths.delete(checkbox.dataset.path);
+        }
+      });
+      
+      updateSelectedPathsDisplay();
+      generateBtn.disabled = selectedPaths.size === 0;
+    });
+    
+    // Fetch file content
+    async function fetchFileContent(owner, repo, branch, token, path) {
+      try {
+        // Check if we have this file cached
+        if (fileCache[path]) {
+          return fileCache[path];
+        }
+        
+        const url = `https://api.github.com/repos/${owner}/${repo}/contents/${path}?ref=${branch}`;
+        const response = await fetch(url, {
+          headers: {
+            'Authorization': `token ${token}`,
+            'Accept': 'application/vnd.github.v3+json'
+          }
+        });
+        
+        if (!response.ok) {
+          throw new Error(`Failed to fetch file content: ${response.statusText}`);
+        }
+        
+        const data = await response.json();
+        
+        // GitHub API returns content as base64
+        const content = atob(data.content);
+        
+        // Cache the content
+        fileCache[path] = content;
+        
+        return content;
+      } catch (error) {
+        console.error(`Error fetching content for ${path}:`, error);
+        return `Error: Could not fetch content for ${path}: ${error.message}`;
+      }
+    }
+    
+    // Process files locally
+    async function processFilesLocally(owner, repo, branch, token) {
+      const options = {
+        lineNumbers: document.getElementById('line-numbers').checked,
+        includeHidden: document.getElementById('include-hidden').checked,
+        outputFormat: document.getElementById('output-format').value
+      };
+      
+      let output = '';
+      
+      // Process each selected path
+      for (const path of selectedPaths) {
+        try {
+          // Check if this is a directory
+          const url = `https://api.github.com/repos/${owner}/${repo}/contents/${path}?ref=${branch}`;
+          const response = await fetch(url, {
+            headers: {
+              'Authorization': `token ${token}`,
+              'Accept': 'application/vnd.github.v3+json'
+            }
+          });
+          
+          if (!response.ok) {
+            throw new Error(`Failed to fetch ${path}: ${response.statusText}`);
+          }
+          
+          const data = await response.json();
+          
+          if (Array.isArray(data)) {
+            // This is a directory, process each file
+            for (const item of data) {
+              if (item.type === 'file') {
+                const filePath = `${path}/${item.name}`;
+                
+                // Skip hidden files if not including them
+                if (!options.includeHidden && item.name.startsWith('.')) {
+                  continue;
+                }
+                
+                const content = await fetchFileContent(owner, repo, branch, token, filePath);
+                
+                // Add to output based on format
+                if (options.outputFormat === 'markdown') {
+                  output += `${filePath}\n\`\`\`\n`;
+                  if (options.lineNumbers) {
+                    const lines = content.split('\n');
+                    output += lines.map((line, i) => `${i + 1} ${line}`).join('\n');
+                  } else {
+                    output += content;
+                  }
+                  output += '\n\`\`\`\n\n';
+                } else if (options.outputFormat === 'cxml') {
+                  output += `<document>\n<source>${filePath}</source>\n<document_content>\n`;
+                  if (options.lineNumbers) {
+                    const lines = content.split('\n');
+                    output += lines.map((line, i) => `${i + 1} ${line}`).join('\n');
+                  } else {
+                    output += content;
+                  }
+                  output += '\n</document_content>\n</document>\n\n';
+                } else {
+                  // Default format
+                  output += `${filePath}\n---\n`;
+                  if (options.lineNumbers) {
+                    const lines = content.split('\n');
+                    output += lines.map((line, i) => `${i + 1} ${line}`).join('\n');
+                  } else {
+                    output += content;
+                  }
+                  output += '\n\n';
+                }
+              }
+            }
+          } else {
+            // This is a file
+            const content = await fetchFileContent(owner, repo, branch, token, path);
+            
+            // Add to output based on format
+            if (options.outputFormat === 'markdown') {
+              output += `${path}\n\`\`\`\n`;
+              if (options.lineNumbers) {
+                const lines = content.split('\n');
+                output += lines.map((line, i) => `${i + 1} ${line}`).join('\n');
+              } else {
+                output += content;
+              }
+              output += '\n\`\`\`\n\n';
+            } else if (options.outputFormat === 'cxml') {
+              output += `<document>\n<source>${path}</source>\n<document_content>\n`;
+              if (options.lineNumbers) {
+                const lines = content.split('\n');
+                output += lines.map((line, i) => `${i + 1} ${line}`).join('\n');
+              } else {
+                output += content;
+              }
+              output += '\n</document_content>\n</document>\n\n';
+            } else {
+              // Default format
+              output += `${path}\n---\n`;
+              if (options.lineNumbers) {
+                const lines = content.split('\n');
+                output += lines.map((line, i) => `${i + 1} ${line}`).join('\n');
+              } else {
+                output += content;
+              }
+              output += '\n\n';
+            }
+          }
+        } catch (error) {
+          console.error(`Error processing ${path}:`, error);
+          output += `Error processing ${path}: ${error.message}\n\n`;
+        }
+      }
+      
+      // Wrap CXML output in documents tags
+      if (options.outputFormat === 'cxml') {
+        output = `<documents>\n${output}</documents>`;
+      }
+      
+      return output;
+    }
+    
+    // Generate prompt
+    generateBtn.addEventListener('click', async () => {
+      const owner = ownerInput.value.trim();
+      const repo = repoInput.value.trim();
+      const branch = branchInput.value.trim() || 'main';
+      const token = tokenInput.value.trim();
+      
+      if (selectedPaths.size === 0) {
+        alert('Please select at least one file or directory');
+        return;
+      }
+      
+      generateBtn.disabled = true;
+      generateBtn.textContent = 'Generating...';
+      
+      try {
+        if (localProcessingCheckbox.checked) {
+          // Process files locally
+          const output = await processFilesLocally(owner, repo, branch, token);
+          
+          // Display output
+          outputText.textContent = output;
+          outputContainer.style.display = 'block';
+        } else {
+          // Use GitHub workflow (this is a placeholder - in a real implementation, you would trigger a GitHub workflow)
+          alert('GitHub workflow integration is not implemented in this demo. Please use local processing instead.');
+          
+          // For demonstration purposes, we'll still process locally
+          const output = await processFilesLocally(owner, repo, branch, token);
+          
+          // Display output
+          outputText.textContent = output;
+          outputContainer.style.display = 'block';
+        }
+      } catch (error) {
+        console.error('Error generating prompt:', error);
+        alert(`Error generating prompt: ${error.message}`);
+      } finally {
+        generateBtn.disabled = false;
+        generateBtn.textContent = 'Generate Prompt';
+      }
+    });
+    
+    // Copy output to clipboard
+    copyOutputBtn.addEventListener('click', () => {
+      navigator.clipboard.writeText(outputText.textContent)
+        .then(() => {
+          copyOutputBtn.textContent = 'Copied!';
+          setTimeout(() => {
+            copyOutputBtn.textContent = 'Copy to Clipboard';
+          }, 2000);
+        })
+        .catch(err => {
+          console.error('Failed to copy text: ', err);
+          alert('Failed to copy text to clipboard');
+        });
+    });
+    
+    // Download output as file
+    downloadOutputBtn.addEventListener('click', () => {
+      const blob = new Blob([outputText.textContent], { type: 'text/plain' });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      
+      const format = document.getElementById('output-format').value;
+      let extension = 'txt';
+      
+      if (format === 'markdown') {
+        extension = 'md';
+      } else if (format === 'cxml') {
+        extension = 'xml';
+      }
+      
+      a.href = url;
+      a.download = `files-to-prompt.${extension}`;
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(url);
+    });
+    
+    // Load values from URL parameters if present
+    document.addEventListener('DOMContentLoaded', () => {
+      const params = new URLSearchParams(window.location.search);
+      
+      if (params.has('owner')) {
+        ownerInput.value = params.get('owner');
+      }
+      
+      if (params.has('repo')) {
+        repoInput.value = params.get('repo');
+      }
+      
+      if (params.has('branch')) {
+        branchInput.value = params.get('branch');
+      }
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
This PR adds a GitHub workflow for the files-to-prompt tool. The workflow can be triggered from the GitHub Pages interface to process files from a repository and generate a prompt for use with LLMs.

## Changes

- Created GitHub workflow with workflow_dispatch trigger
- Updated UI to provide workflow instructions
- Modified token input section to make it optional for public repos
- Enhanced error handling for API rate limits
- Updated README with usage instructions